### PR TITLE
Set indent to 4 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Repository Agent Instructions
+
+- Maintain indentation of four spaces in Lua files.
+- This repository has no automated tests.

--- a/init.lua
+++ b/init.lua
@@ -37,6 +37,11 @@ vim.o.updatetime = 250
 -- Decrease mapped sequence wait time
 vim.o.timeoutlen = 300
 
+-- Use four spaces for indentation
+vim.o.tabstop = 4
+vim.o.shiftwidth = 4
+vim.o.expandtab = true
+
 -- Configure how new splits should be opened
 vim.o.splitright = true
 vim.o.splitbelow = true


### PR DESCRIPTION
## Summary
- default to 4 space indentation
- add an `.editorconfig` with the same style
- document repository guidelines in `AGENTS.md`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685e2e197348832e88ab2d769cd5a601